### PR TITLE
Updated money method

### DIFF
--- a/src/fn/locale.js
+++ b/src/fn/locale.js
@@ -83,7 +83,7 @@
         precision = kilo ? 3 : 0;
       }
       if (val === 0) {
-        let res = val.toFixed(precision);
+        let res = val.toFixed(precision).replace('.', decimal);
         if ( currency ){
           res += ' ' + (kilo ? 'K' + currency : currency);
         }


### PR DESCRIPTION
It is replaced '.' with the current string for decimals when the value is 0.